### PR TITLE
Added option to download media instead of play

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ VIDEO_PLAYER="mpv --save-position-on-quit --no-resume-playback" #default
 # the --no-resume-playback flag mpv flag is removed so that it does not restart your saved progress
 # it is worth noting that if you use vlc there are no such flags so they should both VIDEO_PLAYER and RESUME_PLAYER should be "vlc"
 # though vlc isn't very good for the continue watching feature when using m3u files which is what the the RESUME_PLAYER and VIDEO_PLAYER actually attempt to play
-# (there could be some sort of addon for vlc that adds something similar to the feature that mpv has but I am unaware of one if it exists), 
+# (there could be some sort of addon for vlc that adds something similar to the feature that mpv has but I am unaware of one if it exists),
 RESUME_PLAYER="mpv --save-position-on-quit" #default
+
+# the download tool to use when downloading a video instead of playing.  Must accept a file of URLs
+# -c, or --continue will finish partially downloaded files, useful for network interruptions
+# -i, or --input-file allows a file of URLs to be provided to download
+DOWNLOAD_TOOL="wget -c -i"
 
 # any fuzzy finder will do here. It is important to note there are two real types of fuzzy finders: basic fuzzy finders, and menu tools like dmenu/rofi
 # I have made the tool so that it works with both, at the caveat of not being able to give yes/no prompts or other script abilities like renaming the m3u's saved
@@ -75,6 +80,8 @@ Usage: fzmedia [-s MEDIA_ROOT] [-p VIDEO_PLAYER] [-f FUZZY_FINDER] [-m M3U_FILE]
   -r  resume player command  (overrides RESUME_PLAYER)
   -f  fuzzy-finder command   (overrides FUZZY_FINDER)
   -m  path to m3u file       (overrides M3U_FILE)
+  -d  download the video instead of play
+  -t  download tool          (overrides DOWNLOAD_TOOL)
   -h  this help
 ```
 

--- a/fzmedia.sh
+++ b/fzmedia.sh
@@ -239,6 +239,8 @@ navigate_and_play() {
       *)
         if printf '%s\n' "$choice" | grep -qiE '\.m3u$'; then
           if [ ! -z "$DOWNLOAD_MEDIA" ]; then
+              # Strip m3u control lines
+              sed -i '/^#/d' "$M3U_FILE"
               $DOWNLOAD_TOOL "$M3U_FILE"
           else
               $RESUME_PLAYER "${current}${choice}"
@@ -249,6 +251,8 @@ navigate_and_play() {
           FILE="$choice"
           plbuild "$current"
           if [ ! -z "$DOWNLOAD_MEDIA" ]; then
+              # Strip m3u control lines
+              sed -i '/^#/d' "$M3U_FILE"
               $DOWNLOAD_TOOL "$M3U_FILE"
           else
               $VIDEO_PLAYER "$M3U_FILE"

--- a/fzmedia.sh
+++ b/fzmedia.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Parse CLI flags (override config)
-while getopts "s:p:r:f:m:c:h" opt; do
+while getopts "s:p:r:f:m:c:hdt:" opt; do
   case "$opt" in
     s) FLAG_MEDIA_ROOT=$OPTARG ;;
     p) FLAG_VIDEO_PLAYER=$OPTARG ;;
@@ -9,6 +9,8 @@ while getopts "s:p:r:f:m:c:h" opt; do
     f) FLAG_FUZZY_FINDER=$OPTARG ;;
     m) FLAG_M3U_FILE=$OPTARG ;;
     c) FLAG_CACHE_DIR=$OPTARG ;;
+    d) DOWNLOAD_MEDIA="true" ;;
+    t) DOWNLOAD_TOOL=$OPTARG ;;
     h)
       cat <<EOF
 Usage: $(basename "$0") [-s MEDIA_ROOT] [-p VIDEO_PLAYER] [-f FUZZY_FINDER] [-m M3U_FILE]
@@ -19,6 +21,8 @@ Usage: $(basename "$0") [-s MEDIA_ROOT] [-p VIDEO_PLAYER] [-f FUZZY_FINDER] [-m 
   -f  fuzzy-finder command   (overrides FUZZY_FINDER)
   -m  path to m3u file       (overrides M3U_FILE)
   -c  path to cache dir      (overrides CACHE_DIR)
+  -d  download the video instead of play
+  -t  download tool          (overrides DOWNLOAD_TOOL)
   -h  this help
 EOF
       exit 0
@@ -45,6 +49,7 @@ sourceconf() {
     "MEDIA_ROOT=" \
     "VIDEO_PLAYER=mpv --save-position-on-quit --no-resume-playback" \
     "RESUME_PLAYER=mpv --save-position-on-quit" \
+    "DOWNLOAD_TOOL=wget -c -i" \
     "FUZZY_FINDER=fzy" \
     "M3U_FILE=/tmp/fzmedia.m3u" \
     "PREFERRED_ORDER=movies/,tv/,anime/,music/" \
@@ -173,6 +178,10 @@ manage_cache() {
   [ -n "$sel" ] && rm -f "$CACHE_DIR/$sel"
 }
 
+# Parses a .m3u and downloads all files
+# download() {
+# }
+
 # Navigate directories via fuzzy picker and play when reaching media files
 navigate_and_play() {
   local current="${1%/}/"
@@ -229,13 +238,21 @@ navigate_and_play() {
 
       *)
         if printf '%s\n' "$choice" | grep -qiE '\.m3u$'; then
-          $RESUME_PLAYER "${current}${choice}"
+          if [ ! -z "$DOWNLOAD_MEDIA" ]; then
+              $DOWNLOAD_TOOL "$M3U_FILE"
+          else
+              $RESUME_PLAYER "${current}${choice}"
+          fi
           break
 
         elif printf '%s\n' "$choice" | grep -qiE "$MEDIA_REGEX"; then
           FILE="$choice"
           plbuild "$current"
-          $VIDEO_PLAYER "$M3U_FILE"
+          if [ ! -z "$DOWNLOAD_MEDIA" ]; then
+              $DOWNLOAD_TOOL "$M3U_FILE"
+          else
+              $VIDEO_PLAYER "$M3U_FILE"
+          fi
           cont_watch "$M3U_FILE" "$choice"
           rm -f "$M3U_FILE"
           break


### PR DESCRIPTION
This adds a -d option to download the requested media instead of stream.  It supports specifying an alternative download tool via cli or env.

The default tool is wget, which is installed on most systems and has the ability to resume partial downloads in case of interruption.